### PR TITLE
Ignore automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+Makefile.old
+blib
+pm_to_blib


### PR DESCRIPTION
The files to be ignored include those produced by building the module, testing it, and those generated by running `make clean`.  This helps the output of `git status` stay clean during development.
