### PR TITLE
Add minimum Perl version

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -10,6 +10,7 @@ distribution_type:   module
 requires:
     Set::IntSpan:                  0
     Test::More:                    0
+    perl:                          5.008000
 meta-spec:
     url:     http://module-build.sourceforge.net/META-spec-v1.3.html
     version: 1.3

--- a/META.yml
+++ b/META.yml
@@ -3,11 +3,11 @@ name:                Set-IntSpan-Partition
 version:             0.01
 abstract:            Partition int sets using Set::IntSpan objects
 license:             perl
-author:              
+author:
     - Bjoern Hoehrmann <bjoern@hoehrmann.de>
 generated_by:        ExtUtils::MakeMaker version 6.42_01
 distribution_type:   module
-requires:     
+requires:
     Set::IntSpan:                  0
     Test::More:                    0
 meta-spec:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ WriteMakefile(
   ABSTRACT_FROM     => 'lib/Set/IntSpan/Partition.pm',
   AUTHOR            => 'Bjoern Hoehrmann <bjoern@hoehrmann.de>',
   LICENSE           => 'perl',
+  MIN_PERL_VERSION  => 5.008000,
 
   'dist'            => {
     PREOP     => 'chmod 600 Makefile.PL',


### PR DESCRIPTION
These changes set the minimum Perl version as recommended by the extra CPANTS kwalitee metrics.

In working on this PR I noticed that that since the `META.yml` is automatically generated, it should be removed from the repo.  Is it OK to remove it?
