### PR TITLE
Remove Subversion Id tags

### DIFF
--- a/t/98podsyn.t
+++ b/t/98podsyn.t
@@ -1,6 +1,4 @@
 # 99pod.t -- Minimally check POD for problems.
-#
-# $Id$
 
 use strict;
 use warnings;

--- a/t/99podcov.t
+++ b/t/99podcov.t
@@ -1,6 +1,4 @@
 # 99pod.t -- Minimally check POD for code coverage.
-#
-# $Id$
 
 use strict;
 use warnings;


### PR DESCRIPTION
The repository is now in Git; the Subversion tags are no longer necessary.
