### PR TITLE
Add the 'strict' and 'warnings' pragmas to the tests

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 # Before `make install' is performed this script should be runnable with
 # `make test'. After `make install' it should work as `perl Set-IntSpan-Partition.t'
 

--- a/t/02simple.t
+++ b/t/02simple.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 
 use Test::More tests => 1;
 

--- a/t/03comp.t
+++ b/t/03comp.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 use Set::IntSpan;
 use Set::IntSpan::Partition;


### PR DESCRIPTION
Although the tests were localising the variables nicely, using these pragmas
adds a handy saftey net when making changes to the tests in the future.
