### PR TITLE
Replace string eval with block eval

### DIFF
--- a/t/98podsyn.t
+++ b/t/98podsyn.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-eval "use Test::Pod 1.00";
+
+eval { use Test::Pod 1.00 };
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 all_pod_files_ok();

--- a/t/99podcov.t
+++ b/t/99podcov.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 
-eval "use Test::Pod::Coverage";
+eval { use Test::Pod::Coverage };
 plan skip_all => "Test::Pod::Coverage required for testing pod coverage" if $@;
 plan tests => 1;
 


### PR DESCRIPTION
According to Perl Best Practices, string `eval` should be avoided, hence
this change.
