### PR TITLE
Add examples of Set::IntSpan::Partition usage

### DIFF
--- a/eg/bioinfo_non_overlapping_coords.pl
+++ b/eg/bioinfo_non_overlapping_coords.pl
@@ -1,0 +1,32 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Set::IntSpan;
+use Set::IntSpan::Partition qw(intspan_partition);
+
+# bioinformatics problem: https://www.biostars.org/p/7825/
+#
+# How To Get Non-Overlapping Coordinates From A List That Contains
+# Overlapping Coordinates?
+#
+# chr1    1       10
+# chr1    15      20
+# chr1    17      30
+# chr1    18      19
+#
+# This maps to the intervals (1, 10), (15, 20), (17, 30) and (18, 19).
+# What is the list of non-overlapping intervals?
+
+my @spans = (
+    Set::IntSpan->new('1-10'),
+    Set::IntSpan->new('15-20'),
+    Set::IntSpan->new('17-30'),
+    Set::IntSpan->new('18-19'),
+);
+
+my @output = intspan_partition @spans;
+my @sorted = sort { $a cmp $b } map "$_", @output;
+
+print join ',', @sorted;

--- a/eg/google_interview_question.pl
+++ b/eg/google_interview_question.pl
@@ -31,18 +31,3 @@ push @spans, $span_to_merge;
 my @output = intspan_partition @spans;
 
 print join ',', @output;
-
-
-
-# bioinformatics problem: https://www.biostars.org/p/7825/
-#
-# How To Get Non-Overlapping Coordinates From A List That Contains
-# Overlapping Coordinates?
-#
-# chr1    1       10
-# chr1    15      20
-# chr1    17      30
-# chr1    18      19
-#
-# This maps to the intervals (1, 10), (15, 20), (17, 30) and (18, 19).
-# What is the list of non-overlapping intervals?

--- a/eg/google_interview_question.pl
+++ b/eg/google_interview_question.pl
@@ -1,0 +1,48 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Set::IntSpan;
+use Set::IntSpan::Partition qw(intspan_partition);
+
+# http://www.careercup.com/question?id=13014685
+#
+# Google interview question.
+# Given a set of non overlapping intervals
+# (1,5) (6, 15) (20, 21) (23, 26) (27, 30) (35, 40)
+# and another interval (14, 33), merge them and find the result.
+#
+# Expected output: (1,5) (6, 33) (35, 40)
+
+my @spans = (
+    Set::IntSpan->new('1-5'),
+    Set::IntSpan->new('6-15'),
+    Set::IntSpan->new('20-21'),
+    Set::IntSpan->new('23-26'),
+    Set::IntSpan->new('27-30'),
+    Set::IntSpan->new('35-40'),
+);
+
+my $span_to_merge = Set::IntSpan->new('14-33');
+
+push @spans, $span_to_merge;
+
+my @output = intspan_partition @spans;
+
+print join ',', @output;
+
+
+
+# bioinformatics problem: https://www.biostars.org/p/7825/
+#
+# How To Get Non-Overlapping Coordinates From A List That Contains
+# Overlapping Coordinates?
+#
+# chr1    1       10
+# chr1    15      20
+# chr1    17      30
+# chr1    18      19
+#
+# This maps to the intervals (1, 10), (15, 20), (17, 30) and (18, 19).
+# What is the list of non-overlapping intervals?


### PR DESCRIPTION
The examples added in this PR are attempts at using `Set::IntSpan::Partition` in a scenario useful to a potential user of the module.  However, I'm not 100% sure that they are good examples, since each basically expects that the intervals are merged, which `S::IS::P` doesn't do.  Comments and recommendations for improvements most certainly welcome.
