### PR TITLE
Specify minimum required versions of Heap::Simple* modules

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,8 +7,8 @@ WriteMakefile(
   PREREQ_PM         => {
     'Test::More'         =>  0,
     'Set::IntSpan'       =>  0,
-    'Heap::Simple'       =>  0,
-    'Heap::Simple::XS'   =>  0,
+    'Heap::Simple'       =>  0.13,
+    'Heap::Simple::XS'   =>  0.10,
     'List::Util'         =>  0,
     'List::MoreUtils'    =>  0,
   },


### PR DESCRIPTION
This will stop users from installing outdated versions of these modules and
at the same time address the two CPAN testers failures, which were caused by
the tester having installed an outdated version of Heap::Simple (version 0.6
instead of version 0.13), which in turn had caused the false negatives for
Set::IntSpan::Partition.
